### PR TITLE
chore(ci): restaura infra de deploy da homolog (workflows + manifestos k8s)

### DIFF
--- a/.github/workflows/deploy-builder-homolog.yml
+++ b/.github/workflows/deploy-builder-homolog.yml
@@ -1,0 +1,86 @@
+name: Build and Deploy botflow-builder to GKE (HOMOLOG)
+
+on:
+  push:
+    branches:
+      - homolog
+
+env:
+  GCP_PROJECT_ID: "techpet-dev-01"
+  GCP_WORKLOAD_IDENTITY_PROVIDER: "projects/98980100661/locations/global/workloadIdentityPools/github-actions-pool-2/providers/github-actions-provider"
+  GCP_SERVICE_ACCOUNT: "github-actions-runner@techpet-dev-01.iam.gserviceaccount.com"
+  GKE_CLUSTER: "dev-gke-autopilot-cluster"
+  GKE_LOCATION: "us-central1"
+  ARTIFACT_REGISTRY: "us-central1-docker.pkg.dev"
+  IMAGE_NAME: "botflow-builder"
+  K8S_MANIFEST_DIR: "k8s/homolog/builder/"
+  K8S_NAMESPACE: "tecpet-dev-app"
+
+jobs:
+  build-and-push:
+    name: Build and Push to Artifact Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    outputs:
+      IMAGE_TAG: ${{ steps.build-push.outputs.IMAGE_TAG }}
+
+    steps:
+    - name: "Checkout Repository"
+      uses: actions/checkout@v4
+
+    - name: "Authenticate to Google Cloud"
+      uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+
+    - name: "Configure Docker"
+      run: gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
+
+    - name: "Build and Push Docker Image"
+      id: build-push
+      run: |
+        IMAGE_TAG="${{ env.ARTIFACT_REGISTRY }}/${{ env.GCP_PROJECT_ID }}/techpet-dev-01-tecpet-main/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+        docker build -t $IMAGE_TAG . --build-arg SCOPE=builder
+        docker push $IMAGE_TAG
+        echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to GKE
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    - name: "Checkout Repository"
+      uses: actions/checkout@v4
+
+    - name: "Authenticate to Google Cloud"
+      uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+
+    - name: "Install gke-gcloud-auth-plugin"
+      run: gcloud components install gke-gcloud-auth-plugin
+
+    - name: "Get GKE Credentials"
+      run: gcloud container clusters get-credentials ${{ env.GKE_CLUSTER }} --region ${{ env.GKE_LOCATION }}
+
+    - name: "Update Kubernetes Manifests"
+      run: |
+        sed -i "s|IMAGE_PLACEHOLDER|${{ needs.build-and-push.outputs.IMAGE_TAG }}|g" "${{ env.K8S_MANIFEST_DIR }}/builder-app.yaml"
+
+    - name: "Deploy to GKE"
+      run: |
+        kubectl apply -f "${{ env.K8S_MANIFEST_DIR }}" -n ${{ env.K8S_NAMESPACE }}

--- a/.github/workflows/deploy-viewer-homolog.yml
+++ b/.github/workflows/deploy-viewer-homolog.yml
@@ -1,0 +1,86 @@
+name: Build and Deploy botflow-viewer to GKE (HOMOLOG)
+
+on:
+  push:
+    branches:
+      - homolog
+
+env:
+  GCP_PROJECT_ID: "techpet-dev-01"
+  GCP_WORKLOAD_IDENTITY_PROVIDER: "projects/98980100661/locations/global/workloadIdentityPools/github-actions-pool-2/providers/github-actions-provider"
+  GCP_SERVICE_ACCOUNT: "github-actions-runner@techpet-dev-01.iam.gserviceaccount.com"
+  GKE_CLUSTER: "dev-gke-autopilot-cluster"
+  GKE_LOCATION: "us-central1"
+  ARTIFACT_REGISTRY: "us-central1-docker.pkg.dev"
+  IMAGE_NAME: "botflow-viewer"
+  K8S_MANIFEST_DIR: "k8s/homolog/viewer/"
+  K8S_NAMESPACE: "tecpet-dev-app"
+
+jobs:
+  build-and-push:
+    name: Build and Push to Artifact Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    outputs:
+      IMAGE_TAG: ${{ steps.build-push.outputs.IMAGE_TAG }}
+
+    steps:
+    - name: "Checkout Repository"
+      uses: actions/checkout@v4
+
+    - name: "Authenticate to Google Cloud"
+      uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+
+    - name: "Configure Docker"
+      run: gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
+
+    - name: "Build and Push Docker Image"
+      id: build-push
+      run: |
+        IMAGE_TAG="${{ env.ARTIFACT_REGISTRY }}/${{ env.GCP_PROJECT_ID }}/techpet-dev-01-tecpet-main/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+        docker build -t $IMAGE_TAG . --build-arg SCOPE=viewer
+        docker push $IMAGE_TAG
+        echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to GKE
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    - name: "Checkout Repository"
+      uses: actions/checkout@v4
+
+    - name: "Authenticate to Google Cloud"
+      uses: "google-github-actions/auth@v2"
+      with:
+        workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+    - name: "Set up Cloud SDK"
+      uses: "google-github-actions/setup-gcloud@v2"
+
+    - name: "Install gke-gcloud-auth-plugin"
+      run: gcloud components install gke-gcloud-auth-plugin
+
+    - name: "Get GKE Credentials"
+      run: gcloud container clusters get-credentials ${{ env.GKE_CLUSTER }} --region ${{ env.GKE_LOCATION }}
+
+    - name: "Update Kubernetes Manifests"
+      run: |
+        sed -i "s|IMAGE_PLACEHOLDER|${{ needs.build-and-push.outputs.IMAGE_TAG }}|g" "${{ env.K8S_MANIFEST_DIR }}/viewer-app.yaml"
+
+    - name: "Deploy to GKE"
+      run: |
+        kubectl apply -f "${{ env.K8S_MANIFEST_DIR }}" -n ${{ env.K8S_NAMESPACE }}

--- a/k8s/homolog/builder/builder-app.yaml
+++ b/k8s/homolog/builder/builder-app.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: botflow-builder-homolog-app
+  annotations:
+    secret.reloader.stakater.com/reload: "botflow-builder-homolog-secrets"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: botflow-builder-homolog-app
+  template:
+    metadata:
+      labels:
+        app: botflow-builder-homolog-app
+        department: backend
+        environment: HOMOLOG
+    spec:
+      containers:
+      - name: botflow-builder-homolog-app
+        image: IMAGE_PLACEHOLDER
+        ports:
+        - containerPort: 3000
+        env:
+        - name: PORT
+          value: "3000"
+        envFrom:
+        - secretRef:
+            name: botflow-builder-homolog-secrets
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: 3000
+          initialDelaySeconds: 120
+          periodSeconds: 15
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: 3000
+          initialDelaySeconds: 120
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cloud.google.com/backend-config: '{"ports": {"80":"botflow-builder-homolog-backendconfig"}}'
+  name: botflow-builder-homolog-service
+spec:
+  type: ClusterIP
+  selector:
+    app: botflow-builder-homolog-app
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 3000

--- a/k8s/homolog/builder/builder-backendconfig.yaml
+++ b/k8s/homolog/builder/builder-backendconfig.yaml
@@ -1,0 +1,11 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: botflow-builder-homolog-backendconfig
+  namespace: tecpet-dev-app
+spec:
+  healthCheck:
+    checkIntervalSec: 30
+    port: 3000
+    type: HTTP
+    requestPath: /api/health

--- a/k8s/homolog/builder/builder-external-secret.yaml
+++ b/k8s/homolog/builder/builder-external-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: botflow-builder-homolog-secrets
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: SecretStore
+  target:
+    name: botflow-builder-homolog-secrets
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: botflow-builder-homolog-secrets

--- a/k8s/homolog/builder/builder-scaled-object.yaml
+++ b/k8s/homolog/builder/builder-scaled-object.yaml
@@ -1,0 +1,18 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: botflow-builder-homolog-scheduled-scaler
+  namespace: tecpet-dev-app
+spec:
+  scaleTargetRef:
+    name: botflow-builder-homolog-app
+  minReplicaCount: 0
+  maxReplicaCount: 3
+  cooldownPeriod: 300
+  triggers:
+    - type: cron
+      metadata:
+        timezone: America/Sao_Paulo
+        start: 59 19 * * 1-5
+        end: 0 20 * * 1-5
+        desiredReplicas: "1"

--- a/k8s/homolog/viewer/viewer-app.yaml
+++ b/k8s/homolog/viewer/viewer-app.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: botflow-viewer-homolog-app
+  annotations:
+    secret.reloader.stakater.com/reload: "botflow-viewer-homolog-secrets"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: botflow-viewer-homolog-app
+  template:
+    metadata:
+      labels:
+        app: botflow-viewer-homolog-app
+        department: backend
+        environment: HOMOLOG
+    spec:
+      containers:
+      - name: botflow-viewer-homolog-app
+        image: IMAGE_PLACEHOLDER
+        ports:
+        - containerPort: 3000
+        env:
+        - name: PORT
+          value: "3000"
+        envFrom:
+        - secretRef:
+            name: botflow-viewer-homolog-secrets
+        readinessProbe:
+          httpGet:
+            path: /api/healthz
+            port: 3000
+            httpHeaders:
+            - name: "X-Forwarded-Host"
+              value: "botflow-viewer-homolog.tecpet.dev"
+          initialDelaySeconds: 120
+          periodSeconds: 15
+        livenessProbe:
+          httpGet:
+            path: /api/healthz
+            port: 3000
+            httpHeaders:
+            - name: "X-Forwarded-Host"
+              value: "botflow-viewer-homolog.tecpet.dev"
+          initialDelaySeconds: 120
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cloud.google.com/backend-config: '{"ports": {"80":"botflow-viewer-homolog-backendconfig"}}'
+  name: botflow-viewer-homolog-service
+spec:
+  type: ClusterIP
+  selector:
+    app: botflow-viewer-homolog-app
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 3000

--- a/k8s/homolog/viewer/viewer-backendconfig.yaml
+++ b/k8s/homolog/viewer/viewer-backendconfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: botflow-viewer-homolog-backendconfig
+  namespace: tecpet-dev-app
+spec:
+  healthCheck:
+    checkIntervalSec: 30
+    port: 3000
+    type: HTTP
+    requestPath: /api/healthz
+  customRequestHeaders:
+    headers:
+    - "x-forwarded-host: botflow-viewer-homolog.tecpet.dev"

--- a/k8s/homolog/viewer/viewer-external-secret.yaml
+++ b/k8s/homolog/viewer/viewer-external-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: botflow-viewer-homolog-secrets
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: SecretStore
+  target:
+    name: botflow-viewer-homolog-secrets
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: botflow-viewer-homolog-secrets

--- a/k8s/homolog/viewer/viewer-scaled-object.yaml
+++ b/k8s/homolog/viewer/viewer-scaled-object.yaml
@@ -1,0 +1,18 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: botflow-viewer-homolog-scheduled-scaler
+  namespace: tecpet-dev-app
+spec:
+  scaleTargetRef:
+    name: botflow-viewer-homolog-app
+  minReplicaCount: 0
+  maxReplicaCount: 3
+  cooldownPeriod: 300
+  triggers:
+    - type: cron
+      metadata:
+        timezone: America/Sao_Paulo
+        start: 59 19 * * 1-5
+        end: 0 20 * * 1-5
+        desiredReplicas: "1"


### PR DESCRIPTION
## Contexto

A infra de deploy da **homolog** do botflow tinha sumido do \`origin/homolog\`: faltavam **2 workflows** e os **8 manifestos k8s** que eles aplicam.

### Causa raiz
Não houve deleção explícita. Os arquivos foram descartados silenciosamente na resolução do merge **\`c6e355476\`** ("Merge branch 'homolog'", 19/06/2026), que resolveu ficando com a mainline — linha que nunca carregou esses arquivos (eles vinham do parent2 \`b4b27669f\`). Por ser um "evil merge", nenhum \`git log -- <path>\` ou \`--diff-filter=D\` aponta um commit de remoção.

## O que este PR restaura (de \`b4b27669f\`)

**Workflows** (trigger em \`push\` para \`homolog\`):
- \`.github/workflows/deploy-builder-homolog.yml\`
- \`.github/workflows/deploy-viewer-homolog.yml\`

**Manifestos k8s** (aplicados via \`kubectl apply\` pelos workflows):
- \`k8s/homolog/builder/\` — \`builder-app.yaml\`, \`builder-backendconfig.yaml\`, \`builder-external-secret.yaml\`, \`builder-scaled-object.yaml\`
- \`k8s/homolog/viewer/\` — \`viewer-app.yaml\`, \`viewer-backendconfig.yaml\`, \`viewer-external-secret.yaml\`, \`viewer-scaled-object.yaml\`

Restaurar apenas o workflow do builder deixaria o pipeline quebrado (o passo de deploy referencia \`k8s/homolog/builder/\`, que não existia mais). Por isso o conjunto completo foi reintroduzido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)